### PR TITLE
add support for provider and function environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,15 @@ custom:
 ```
 
 #### pollForever
-* can be set to `true` to indicate that this plugin should continue to poll for dynamodbstreams events indefinity. if
+* pollForever can be set to `true` to indicate that this plugin should continue to poll for dynamodbstreams events indefinity. If
 `pollForever` is not set, or is set to false, the plugin will stop polling for events once the end of the
-stream is reached (when dynamodbstreams.getRecords => data.NextShardIterator === null). this can be useful in scenarios where you have a lambda function as part of a larger service struture, and the other services depend on the functinality in the lambda.
+stream is reached (when dynamodbstreams.getRecords => data.NextShardIterator === null), or an error occurs.
+
+* With `pollForever` set to `true` the following events will trigger a restart instead of exiting as would happen with `pollForever` set to `false`:
+    * The end of a Dynamodb Stream is reached (when dynamodbstreams.getRecords => data.NextShardIterator === null)
+    *  [ExpiredIteratorException](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetRecords.html) is thrown from `dynamodbstreams.getRecords`.
+
+* This can be useful in scenarios where you have a lambda function as part of a larger service struture, and the other services depend on the functinality in the lambda.
 
 Ensure your local dynamodb is up and running, or you could also consider using [serverless-dynamodb-local](https://github.com/99xt/serverless-dynamodb-local) plugin before start your serverless offline process.
 

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ class ServerlessPluginOfflineDynamodbStream {
           });
 
           readable.pipe(functionExecutable).on('end', () => {
-            console.log(`stream for table [${table}] ended!`);
+            console.log(`stream for table [${table}] closed!`);
           });
         }
       });

--- a/src/index.js
+++ b/src/index.js
@@ -39,12 +39,15 @@ class ServerlessPluginOfflineDynamodbStream {
         region,
         batchSize,
         pollForever = false
-      } = {}
+      } = {},
+      serverless: { service: { provider: { environment } = {} } = {} } = {}
     } = this;
     const endpoint = new AWS.Endpoint(`http://${hostname}:${port}`);
     const offlineConfig =
       this.serverless.service.custom['serverless-offline'] || {};
     const fns = this.serverless.service.functions;
+
+    process.env = Object.assign({}, process.env, environment);
 
     let location = process.cwd();
     if (offlineConfig.location) {
@@ -90,9 +93,18 @@ class ServerlessPluginOfflineDynamodbStream {
               highWaterMark: batchSize
             }
           );
+
           const functionExecutable = FunctionExecutable(location, functions);
+
+          readable.on('error', (error) => {
+            console.log(
+              `DynamoDBStreamReadable error... terminating stream... Error => ${error}`
+            );
+            functionExecutable.destroy(error);
+          });
+
           readable.pipe(functionExecutable).on('end', () => {
-            console.log(`stream for table [${table}] closed!`);
+            console.log(`stream for table [${table}] ended!`);
           });
         }
       });


### PR DESCRIPTION
Hey @emmkong, thanks for merging the pr I made the other day. I've got a few more contributions I'd like to add. please let me know if you'd like me to make any changes, or if you have any concerns about the implementation.

In this pr I've done 4 things: 
1. I added an error handler for the readable stream which will kill the stream on an error. you can see this in index.js on line 99. 
2. I've added handling for the `ExpiredIteratorException` which you can see in DynamoDBStreamReadable.js on line 94. The reason I added this is because in cases where a program pauses for some reason (i.e debugger attached, computer sleeps), the `shardIterator`, which expires in 15 mins, is held on to and used after the program resumes. In cases where the pause was long enough for the `shardIterator` to expire, we get an `ExpiredIteratorException`.
3. I've also added support for environment variables from the provider and function properties in the  serverless.yml file.
4. I've updated the documentation to represent the new changes.